### PR TITLE
Added new IGotoFile provider ExternalFile to enable opening any file in ...

### DIFF
--- a/src/EveningCreek.ReSharper.ExternalCode/EveningCreek.ReSharper.ExternalCode.8.1.csproj
+++ b/src/EveningCreek.ReSharper.ExternalCode/EveningCreek.ReSharper.ExternalCode.8.1.csproj
@@ -65,6 +65,9 @@
     </Compile>
     <Compile Include="ExternalCodeSettingsAccessor.cs" />
     <Compile Include="ExternalCodeSettingsKey.cs" />
+    <Compile Include="ExternalFiles.cs" />
+    <Compile Include="FileOccurence.cs" />
+    <Compile Include="FileOccurencePresenter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\PluginInfo.cs" />
   </ItemGroup>

--- a/src/EveningCreek.ReSharper.ExternalCode/EveningCreek.ReSharper.ExternalCode.8.2.csproj
+++ b/src/EveningCreek.ReSharper.ExternalCode/EveningCreek.ReSharper.ExternalCode.8.2.csproj
@@ -65,6 +65,9 @@
     </Compile>
     <Compile Include="ExternalCodeSettingsAccessor.cs" />
     <Compile Include="ExternalCodeSettingsKey.cs" />
+    <Compile Include="ExternalFiles.cs" />
+    <Compile Include="FileOccurence.cs" />
+    <Compile Include="FileOccurencePresenter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\PluginInfo.cs" />
   </ItemGroup>

--- a/src/EveningCreek.ReSharper.ExternalCode/ExternalFiles.cs
+++ b/src/EveningCreek.ReSharper.ExternalCode/ExternalFiles.cs
@@ -1,0 +1,189 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Windows.Documents;
+using JetBrains.Application.FileSystemTracker;
+using JetBrains.Application.Settings;
+using JetBrains.DataFlow;
+using JetBrains.DocumentManagers;
+using JetBrains.DocumentModel;
+using JetBrains.IDE;
+using JetBrains.ProjectModel;
+using JetBrains.ProjectModel.Properties;
+using JetBrains.ReSharper.ExternalSources.ReSharperIntegration;
+using JetBrains.ReSharper.Feature.Services.Goto;
+using JetBrains.ReSharper.Feature.Services.Navigation;
+using JetBrains.ReSharper.Feature.Services.Navigation.Navigation.NavigationProviders;
+using JetBrains.ReSharper.Feature.Services.Navigation.Occurences;
+using JetBrains.ReSharper.Feature.Services.Navigation.Search;
+using JetBrains.ReSharper.Feature.Services.Occurences;
+using JetBrains.ReSharper.Feature.Services.Occurences.Presentation;
+using JetBrains.ReSharper.Features.StructuralSearch.Finding;
+using JetBrains.ReSharper.I18n.Services.Navigation;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.ExtensionsAPI.Caches2;
+using JetBrains.ReSharper.Psi.JavaScript.Impl.Tree;
+using JetBrains.ReSharper.Psi.Resolve;
+using JetBrains.ReSharper.Psi.Services.StructuralSearch.Impl;
+using JetBrains.ReSharper.Psi.Xml.Impl.Tree;
+using JetBrains.Text;
+using JetBrains.UI.PopupMenu;
+using JetBrains.UI.PopupWindowManager;
+using JetBrains.Util;
+using TextRange = JetBrains.Util.TextRange;
+
+namespace EveningCreek.ReSharper.ExternalCode
+{
+    [JetBrains.ReSharper.Psi.ShellFeaturePartAttribute()]
+    public class ExternalFiles : IGotoFileProvider
+    {
+        private bool _isInitialised = false;
+        private readonly ISettingsStore _settingsStore;
+        private readonly IFileSystemTracker _fileSystemTracker;
+        private readonly Lifetime _lifetime;
+        private readonly ISettingsChangedEventSource _settingsChangedEventSource;
+
+        private IDictionary<FileSystemPath, MatchingInfo> trackedFiles = new Dictionary<FileSystemPath, MatchingInfo>();
+
+
+        public ExternalFiles(ISettingsStore settingsStore, IFileSystemTracker fileSystemTracker, Lifetime lifetime, ISettingsChangedEventSource settingsChangedEventSource)
+        {
+            _settingsStore = settingsStore;
+            this._fileSystemTracker = fileSystemTracker;
+            this._lifetime = lifetime;
+            this._settingsChangedEventSource = settingsChangedEventSource;
+        }
+
+        public bool IsApplicable(INavigationScope scope, GotoContext gotoContext, IdentifierMatcher matcher)
+        {
+            initialiseFileWatchers(scope);
+            return true;
+        }
+
+        private void initialiseFileWatchers(INavigationScope scope)
+        {
+            if (_isInitialised)
+            {
+                return;
+            }
+            _isInitialised = true;
+
+            var solutionFilePath = scope.GetSolution().SolutionFilePath;
+
+
+            var settingsKey = _settingsStore
+                .BindToContextTransient(ContextRange.ApplicationWide)
+                .GetKey<ExternalCodeSettingsKey>(SettingsOptimization.OptimizeDefault);
+
+            _settingsChangedEventSource.Changed.Advise(_lifetime, (arg) =>
+            {
+                if (arg.ChangedEntries.Any(_ => _.LocalName == "Paths" && _.Parent.LocalName == "ExternalCode"))
+                    updateFilePaths(settingsKey, solutionFilePath);
+            });
+
+            updateFilePaths(settingsKey, solutionFilePath);
+        }
+
+        private void updateFilePaths(ExternalCodeSettingsKey settingsKey, FileSystemPath solutionFilePath)
+        {
+            IEnumerable<string> paths = settingsKey
+                .Paths
+                .EnumIndexedValues()
+                .Select(x => x.Value.Trim())
+                .Distinct();
+
+            FileSystemPath[] fileSystemPaths = paths
+                .Select(FileSystemPath.TryParse)
+                .Select(x => x.ToAbsolutePath(solutionFilePath.Directory))
+                .ToArray();
+
+            foreach (var fileSystemPath in fileSystemPaths)
+            {
+                loadFilesForPath(fileSystemPath);
+                _fileSystemTracker.AdviseFileChanges(_lifetime, fileSystemPath, OnChangeAction);
+            }
+        }
+
+        private void loadFilesForPath(FileSystemPath fileSystemPath)
+        {
+            if (!fileSystemPath.ExistsDirectory)
+                return;
+
+            var filesInPath = Directory.GetFiles(fileSystemPath.FullPath, "*.*", SearchOption.TopDirectoryOnly);
+            foreach (var file in filesInPath)
+            {
+                var systemPath = FileSystemPath.Parse(file);
+                if (systemPath.ExistsFile)
+                {
+                    trackedFiles[systemPath] = infoForFile(file);
+                }
+            }
+        }
+
+        private static MatchingInfo infoForFile(string file)
+        {
+            return new MatchingInfo(file, new[] { new IdentifierMatch(), });
+        }
+
+        private void OnChangeAction(FileSystemChangeDelta fileSystemChangeDelta)
+        {
+            foreach (var systemChangeDelta in fileSystemChangeDelta.GetChildren())
+            {
+                OnChangeAction(systemChangeDelta);
+            }
+
+            if (!fileSystemChangeDelta.NewPath.ExistsFile)
+                return;
+
+            if (fileSystemChangeDelta.ChangeType == FileSystemChangeType.DELETED)
+            {
+                if (trackedFiles.ContainsKey(fileSystemChangeDelta.OldPath))
+                {
+                    trackedFiles.Remove(fileSystemChangeDelta.OldPath);
+                }
+
+                return;
+            }
+
+            handleAddRename(fileSystemChangeDelta);
+        }
+
+        private void handleAddRename(FileSystemChangeDelta fileSystemChangeDelta)
+        {
+            if (fileSystemChangeDelta.OldPath != null)
+            {
+                if (trackedFiles.ContainsKey(fileSystemChangeDelta.OldPath))
+                {
+                    trackedFiles.Remove(fileSystemChangeDelta.OldPath);
+                }
+            }
+            if (fileSystemChangeDelta.NewPath != null)
+            {
+                trackedFiles[fileSystemChangeDelta.NewPath] = infoForFile(fileSystemChangeDelta.NewPath.FullPath);
+            }
+        }
+
+        public IEnumerable<MatchingInfo> FindMatchingInfos(IdentifierMatcher matcher, INavigationScope scope,
+            GotoContext gotoContext,
+            Func<bool> checkForInterrupt)
+        {
+            return trackedFiles.Where(_ => _.Key.Name.Contains(matcher.Filter)).Select(_ => _.Value);
+        }
+
+        public IEnumerable<IOccurence> GetOccurencesByMatchingInfo(MatchingInfo navigationInfo, INavigationScope scope,
+            GotoContext gotoContext,
+            Func<bool> checkForInterrupt)
+        {
+            var fileSystemPath = FileSystemPath.Parse(navigationInfo.Identifier);
+
+            return new List<IOccurence>()
+            {                
+                new FileOccurence(fileSystemPath, new TextRange(), new SimpleMenuItem() {Text = fileSystemPath.Name, }),
+            };
+        }
+
+        public Func<int, int> ItemsPriorityFunc { get; private set; }
+    }
+}

--- a/src/EveningCreek.ReSharper.ExternalCode/FileOccurence.cs
+++ b/src/EveningCreek.ReSharper.ExternalCode/FileOccurence.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using JetBrains.IDE;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Feature.Services.Navigation.Search;
+using JetBrains.ReSharper.Feature.Services.Occurences;
+using JetBrains.ReSharper.Psi;
+using JetBrains.UI.PopupMenu;
+using JetBrains.UI.PopupWindowManager;
+using JetBrains.Util;
+
+namespace EveningCreek.ReSharper.ExternalCode
+{
+    public class FileOccurence : IOccurence
+    {
+        private readonly FileSystemPath myFilePath;
+        private readonly TextRange myTextRange;
+        private readonly IMenuItemDescriptor myCachedPresentation;
+
+        public IMenuItemDescriptor CachedPresentation
+        {
+            get
+            {
+                return this.myCachedPresentation;
+            }
+        }
+
+        public TextRange TextRange
+        {
+            get
+            {
+                return this.myTextRange;
+            }
+        }
+
+        public ProjectModelElementEnvoy ProjectModelElementEnvoy
+        {
+            get
+            {
+                return (ProjectModelElementEnvoy)null;
+            }
+        }
+
+        public DeclaredElementEnvoy<ITypeMember> TypeMember
+        {
+            get
+            {
+                return (DeclaredElementEnvoy<ITypeMember>)null;
+            }
+        }
+
+        public DeclaredElementEnvoy<ITypeElement> TypeElement
+        {
+            get
+            {
+                return (DeclaredElementEnvoy<ITypeElement>)null;
+            }
+        }
+
+        public DeclaredElementEnvoy<INamespace> Namespace
+        {
+            get
+            {
+                return (DeclaredElementEnvoy<INamespace>)null;
+            }
+        }
+
+        public OccurenceType OccurenceType
+        {
+            get
+            {
+                return OccurenceType.Compiled;
+            }
+        }
+
+        public bool IsValid
+        {
+            get { return true; }
+        }
+
+        public object MergeKey
+        {
+            get
+            {
+                return myFilePath.ToString();
+            }
+        }
+
+        public IList<IOccurence> MergedItems
+        {
+            get
+            {
+                return (IList<IOccurence>)EmptyList<IOccurence>.InstanceList;
+            }
+        }
+
+        public OccurencePresentationOptions PresentationOptions { get; set; }
+
+        public FileOccurence(FileSystemPath filePath, TextRange textRange, IMenuItemDescriptor cachedPresentation)
+        {
+            this.myFilePath = filePath;
+            this.myTextRange = textRange;
+            this.myCachedPresentation = cachedPresentation;
+            this.PresentationOptions = OccurencePresentationOptions.DefaultOptions;
+        }
+
+        public bool Navigate(ISolution solution, PopupWindowContextSource windowContext, bool transferFocus, TabOptions tabOptions)
+        {
+            var txtControl = EditorManager.GetInstance(solution).OpenFile(myFilePath, true, TabOptions.NormalTab);
+            return true;
+        }
+
+        public string DumpToString()
+        {
+            return string.Format("[DFO]. Path: {0} \nRange: {1}", (object)this.myFilePath, (object)this.myTextRange);
+        }
+    }
+}

--- a/src/EveningCreek.ReSharper.ExternalCode/FileOccurencePresenter.cs
+++ b/src/EveningCreek.ReSharper.ExternalCode/FileOccurencePresenter.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using JetBrains.ReSharper.Feature.Services.Navigation.Search;
+using JetBrains.ReSharper.Feature.Services.Occurences;
+using JetBrains.ReSharper.Feature.Services.Occurences.Presentation;
+using JetBrains.UI.PopupMenu;
+
+namespace EveningCreek.ReSharper.ExternalCode
+{
+    [OccurencePresenter]
+    public class FileOccurencePresenter : IOccurencePresenter
+    {
+        public bool Present(IMenuItemDescriptor descriptor, IOccurence occurence, OccurencePresentationOptions occurencePresentationOptions)
+        {
+            FileOccurence decompiledFileOccurence = occurence as FileOccurence;
+            if (decompiledFileOccurence == null)
+                return false;
+            if (decompiledFileOccurence.CachedPresentation != null)
+            {
+                IMenuItemDescriptor cachedPresentation = decompiledFileOccurence.CachedPresentation;
+                descriptor.Icon = cachedPresentation.Icon;
+                descriptor.Text = cachedPresentation.Text;
+                descriptor.ShortcutText = cachedPresentation.ShortcutText;
+                descriptor.TailGlyph = cachedPresentation.TailGlyph;
+                descriptor.Tooltip = cachedPresentation.Tooltip;
+                descriptor.Tag = ((object)occurence);
+                descriptor.Style = cachedPresentation.Style;
+            }
+            return true;
+        }
+
+        public bool IsApplicable(IOccurence occurence)
+        {
+            return occurence is FileOccurence;
+        }
+    }
+}


### PR DESCRIPTION
In the current state this extension doesn't seem to support navigation to files in the external folder if they aren't supported language files.

I added an IGotoFile provider which allows navigation to any file within the external folders (not recursive).

On my current project we have sql migration scripts out of the solution and need to easily open them in the VS Editor for preview/updating.

Ideally this functionality would've slotted more easily into the existing resharper code but I couldn't find an existing IOccurence that was able to display the files from the external folder and also open them in the editor.

It caches the file list itself  rather than using any existing resharper cache as it seemed they were more appropriate for caching the PSI related information. There is probably a better way to do this but I couldn't easily see how to use the existing caches.
